### PR TITLE
Fix program hang if version entry not found

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -25,3 +25,4 @@ fi
 
 cd ${BASEPATH}; make
 cd ${BASEPATH}; docker build . -t andyg42/premconverter:${CIRCLE_BUILD}
+cd ${BASEPATH}; docker push andyg42/premconverter:${CIRCLE_BUILD}

--- a/kube/jobs-from-template.sh
+++ b/kube/jobs-from-template.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 NUM_SPLITS=5
-REAL_INPUT_PATH=/path/to/projects
-REAL_OUTPUT_PATH=/path/to/upgraded
-LISTFILE=dev-environment-projects
+REAL_INPUT_PATH=/srv/StudioPipe2/Tests/ProjectsOld
+REAL_OUTPUT_PATH=/srv/StudioPipe2/Tests/ProjectsUpgraded
+LISTFILE=live-env-test
 
 for i in `seq 1 $NUM_SPLITS`; do
     cat templates/RunAsJob.yaml | sed s/\{\{index\}\}/$i/g > /tmp/1

--- a/kube/jobs-from-template.sh
+++ b/kube/jobs-from-template.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 NUM_SPLITS=5
-REAL_INPUT_PATH=/srv/StudioPipe2/Tests/ProjectsOld
-REAL_OUTPUT_PATH=/srv/StudioPipe2/Tests/ProjectsUpgraded
+REAL_INPUT_PATH=/path/to/projects
+REAL_OUTPUT_PATH=/path/to/upgraded
 LISTFILE=live-env-test
 
 for i in `seq 1 $NUM_SPLITS`; do

--- a/kube/templates/RunAsJob.yaml
+++ b/kube/templates/RunAsJob.yaml
@@ -27,7 +27,7 @@ spec:
         - name: premconverter
           imagePullPolicy: Always
           image: andyg42/premconverter:DEV
-          command: ["/usr/local/bin/premconverter","--list", "/mnt/lists/{{listfile}}-{{index}}.lst", "--output", "/mnt/output","--concurrency", "5"]
+          command: ["/usr/local/bin/premconverter","--list", "/mnt/lists/{{listfile}}-{{index}}.lst", "--output", "/mnt/output","--concurrency", "1"]
           resources:
             requests:
               memory: "128Mi"

--- a/src/batcher/batcher.go
+++ b/src/batcher/batcher.go
@@ -29,9 +29,9 @@ func processList(file io.Reader) ([]string, error) {
 	var rtnList = make([]string, INITIAL_LIST_SIZE)
 
 	for scanner.Scan() {
-		log.Printf("len %d, cap %d", lineCounter, cap(rtnList))
+		//log.Printf("len %d, cap %d", lineCounter, cap(rtnList))
 		if lineCounter == cap(rtnList) {
-			log.Printf("exanding rtnList capacity from %d to %d", cap(rtnList), lineCounter+INITIAL_LIST_SIZE)
+			//log.Printf("exanding rtnList capacity from %d to %d", cap(rtnList), lineCounter+INITIAL_LIST_SIZE)
 			newSlice := make([]string, lineCounter+INITIAL_LIST_SIZE)
 			copy(newSlice, rtnList)
 			rtnList = newSlice

--- a/src/batcher/batcher.go
+++ b/src/batcher/batcher.go
@@ -29,8 +29,10 @@ func processList(file io.Reader) ([]string, error) {
 	var rtnList = make([]string, INITIAL_LIST_SIZE)
 
 	for scanner.Scan() {
-		if len(rtnList) == cap(rtnList) {
-			newSlice := make([]string, len(rtnList), len(rtnList)+INITIAL_LIST_SIZE)
+		log.Printf("len %d, cap %d", lineCounter, cap(rtnList))
+		if lineCounter == cap(rtnList) {
+			log.Printf("exanding rtnList capacity from %d to %d", cap(rtnList), lineCounter+INITIAL_LIST_SIZE)
+			newSlice := make([]string, lineCounter+INITIAL_LIST_SIZE)
 			copy(newSlice, rtnList)
 			rtnList = newSlice
 		}

--- a/src/reader/reader.go
+++ b/src/reader/reader.go
@@ -143,7 +143,7 @@ func readToBuffer(reader io.Reader) (*bytes.Buffer, error) {
 }
 
 // Takes a reader and a writer, and applies the version change as a regex
-// On error, returns an error; otherwise returns the number of lines processed.
+// On error, returns an error; otherwise returns the number of lines processed and the number of uncompressed bytes processed
 func Scan(reader io.Reader, writer io.Writer, logtag string) (int, int64, error) {
 	matcher, err := regexp.Compile(`<Project ObjectID="(\d)" ClassID="([\w\d\-]+)" Version="(\d+)">`)
 
@@ -184,7 +184,7 @@ func Scan(reader io.Reader, writer io.Writer, logtag string) (int, int64, error)
 			//fmt.Printf("On line %d\n", lineCounter)
 			for scanner.Scan() {
 				lineCounter += 1
-				fmt.Printf("debug: got line %s\n", scanner.Text())
+				//fmt.Printf("debug: got line %s\n", scanner.Text())
 
 				matches := matcher.FindStringSubmatch(scanner.Text())
 				if matches == nil {

--- a/src/reader/reader.go
+++ b/src/reader/reader.go
@@ -35,7 +35,7 @@ func GzipProcessor(filePathIn string, filePathOut string, allowOverwrite bool) (
 	file, err := os.Open(filePathIn)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return -1, -1, err
 	}
 
@@ -62,7 +62,7 @@ func GzipProcessor(filePathIn string, filePathOut string, allowOverwrite bool) (
 	writeFile, writeErr := os.Create(filePathOut)
 
 	if writeErr != nil {
-		log.Fatalf("[%s] Could not open %s to write: %s", logtag, filePathOut, err)
+		log.Printf("[%s] Could not open %s to write: %s", logtag, filePathOut, err)
 		return -1, -1, err
 	}
 
@@ -90,7 +90,7 @@ func UncompressedProcessor(filePathIn string, filePathOut string, allowOverwrite
 	file, err := os.Open(filePathIn)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return -1, -1, err
 	}
 
@@ -111,7 +111,7 @@ func UncompressedProcessor(filePathIn string, filePathOut string, allowOverwrite
 	writeFile, writeErr := os.Create(filePathOut)
 
 	if writeErr != nil {
-		log.Fatalf("Could not open %s to write: %s", filePathOut, err)
+		log.Printf("Could not open %s to write: %s", filePathOut, err)
 		return -1, -1, err
 	}
 
@@ -135,7 +135,7 @@ func readToBuffer(reader io.Reader) (*bytes.Buffer, error) {
 	bytesRead, err := buffer.ReadFrom(reader)
 
 	if err != nil {
-		log.Fatal("Could not buffer incoming file: ", err)
+		log.Print("Could not buffer incoming file: ", err)
 		return nil, err
 	}
 	log.Printf("Read %d bytes", bytesRead)
@@ -148,7 +148,7 @@ func Scan(reader io.Reader, writer io.Writer, logtag string) (int, int64, error)
 	matcher, err := regexp.Compile(`<Project ObjectID="(\d)" ClassID="([\w\d\-]+)" Version="(\d+)">`)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return -1, -1, err
 	}
 
@@ -167,7 +167,7 @@ func Scan(reader io.Reader, writer io.Writer, logtag string) (int, int64, error)
 			written, err := io.Copy(writer, reader)
 			bytesWritten += written
 			if err != nil {
-				log.Fatalf("[%s] Could not copy remainder of file: %s", logtag, err)
+				log.Printf("[%s] Could not copy remainder of file: %s", logtag, err)
 				return lineCounter, written, err
 			} else {
 				if written == 0 {
@@ -190,19 +190,19 @@ func Scan(reader io.Reader, writer io.Writer, logtag string) (int, int64, error)
 					//log.Print("debug: got no matches\n")
 					_, err := writer.Write(scanner.Bytes())
 					if err != nil {
-						log.Fatal(err)
+						log.Print(err)
 						return -1, -1, err
 					}
 					_, otherErr := writer.Write([]byte("\n"))
 					if otherErr != nil {
-						log.Fatal(err)
+						log.Print(err)
 						return -1, -1, err
 					}
 				} else {
 					//log.Printf("debug: matches: %s", matches)
 					version, err := strconv.ParseInt(matches[3], 10, 32)
 					if err != nil {
-						log.Fatalf("[%s] Detected version was not a number, got %s\n", logtag, matches[3])
+						log.Printf("[%s] Detected version was not a number, got %s\n", logtag, matches[3])
 						return lineCounter, -1, err
 					}
 					log.Printf("[%s] ObjectID is %s, classID is %s, version is %d\n", logtag, matches[1], matches[2], version)
@@ -211,7 +211,7 @@ func Scan(reader io.Reader, writer io.Writer, logtag string) (int, int64, error)
 						//FIXME: should add custom error here.
 						_, writeErr := writer.Write([]byte(scanner.Text()))
 						if writeErr != nil {
-							log.Fatal("Could not write output: ", writeErr)
+							log.Print("Could not write output: ", writeErr)
 						}
 					} else if version > REPLACEMENT_VERSION {
 						log.Printf("[%s] This file is at a higher version (%d) than the replacement (%d).", logtag, version, REPLACEMENT_VERSION)
@@ -220,7 +220,7 @@ func Scan(reader io.Reader, writer io.Writer, logtag string) (int, int64, error)
 						replacementLine := matcher.ReplaceAllString(scanner.Text(), replacementString)
 						_, writeErr := writer.Write([]byte(replacementLine))
 						if writeErr != nil {
-							log.Fatalf("[%s] Could not write output: %s", logtag, writeErr)
+							log.Printf("[%s] Could not write output: %s", logtag, writeErr)
 						}
 						log.Printf("[%s] Version identifier tag updated to %d", logtag, REPLACEMENT_VERSION)
 					}

--- a/src/reader/reader_test.go
+++ b/src/reader/reader_test.go
@@ -62,3 +62,60 @@ func TestScanOK(t *testing.T) {
 		t.Errorf("Expected %s\n", expected)
 	}
 }
+
+// Scan should not block if no Version can be found
+func TestScanAbsent(t *testing.T) {
+	test_data := `<?xml version="1.0" encoding="UTF-8" ?>
+<PremiereData Version="3">
+        <Project ObjectRef="1"/>
+        <Project ObjectID="1">
+                <Node Version="1">
+                        <Properties Version="1">
+                                <ProjectViewState.List ObjectID="2" ClassID="aab0946f-7a21-4425-8908-fafa2119e30e" Version="3">
+                                        <ProjectViewStates Version="1">
+                                                <ProjectViewState Version="1" Index="0">
+                                                        <First>8fd5ff01-787e-41bc-9302-193332660c4c</First>
+                                                        <Second ObjectRef="1"/>
+                                                </ProjectViewState>
+                                                <ProjectViewState Version="1" Index="1">
+                                                        <First>8a4a4716-6f1b-46fc-8b9c-e8c012ee89d4</First>
+                                                        <Second ObjectRef="2"/>
+                                                </ProjectViewState>
+                                        </ProjectViewStates>`
+
+	expected := `<?xml version="1.0" encoding="UTF-8" ?>
+<PremiereData Version="3">
+        <Project ObjectRef="1"/>
+        <Project ObjectID="1">
+                <Node Version="1">
+                        <Properties Version="1">
+                                <ProjectViewState.List ObjectID="2" ClassID="aab0946f-7a21-4425-8908-fafa2119e30e" Version="3">
+                                        <ProjectViewStates Version="1">
+                                                <ProjectViewState Version="1" Index="0">
+                                                        <First>8fd5ff01-787e-41bc-9302-193332660c4c</First>
+                                                        <Second ObjectRef="1"/>
+                                                </ProjectViewState>
+                                                <ProjectViewState Version="1" Index="1">
+                                                        <First>8a4a4716-6f1b-46fc-8b9c-e8c012ee89d4</First>
+                                                        <Second ObjectRef="2"/>
+                                                </ProjectViewState>
+                                        </ProjectViewStates>
+`
+
+	reader := strings.NewReader(test_data)
+	writer := bytes.NewBufferString("")
+
+	lineCount, _, err := Scan(reader, writer, "test")
+
+	if err != nil {
+		t.Errorf("Scan returned an error: %s", err)
+	}
+
+	t.Logf("Processed %d lines", lineCount)
+	output := writer.String()
+
+	if output != expected {
+		t.Errorf("Scan did not process the string properly, got %s\n", output)
+		t.Errorf("Expected %s\n", expected)
+	}
+}


### PR DESCRIPTION
Prevent an eternal loop if the version entry is not found, by breaking if we find blank lines lots of times in a row.